### PR TITLE
Create computer vision foundation package

### DIFF
--- a/packages/bytebot-cv/package.json
+++ b/packages/bytebot-cv/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "@bytebot/cv",
+  "version": "1.0.0",
+  "main": "dist/index.js",
+  "dependencies": {
+    "@types/node": "^20.0.0",
+    "opencv4nodejs": "^5.6.0",
+    "tesseract.js": "^5.0.4",
+    "sharp": "^0.33.0",
+    "fuzzysearch": "^1.0.3",
+    "lodash": "^4.17.21"
+  },
+  "devDependencies": {
+    "typescript": "^5.0.0",
+    "@types/lodash": "^4.14.0"
+  },
+  "scripts": {
+    "build": "tsc",
+    "dev": "tsc --watch"
+  }
+}

--- a/packages/bytebot-cv/src/detectors/edge/edge-detector.ts
+++ b/packages/bytebot-cv/src/detectors/edge/edge-detector.ts
@@ -1,0 +1,100 @@
+import * as cv from 'opencv4nodejs';
+import { BoundingBox, DetectedElement, ElementType } from '../../types';
+
+export class EdgeDetector {
+  async detect(screenshotBuffer: Buffer, region?: BoundingBox): Promise<DetectedElement[]> {
+    if (!screenshotBuffer?.length) {
+      return [];
+    }
+
+    const screenshot = cv.imdecode(screenshotBuffer);
+    const { mat: searchMat, offsetX, offsetY } = this.extractRegion(screenshot, region);
+    const gray = searchMat.cvtColor(cv.COLOR_BGR2GRAY);
+    const blurred = gray.gaussianBlur(new cv.Size(5, 5), 0);
+    const edges = blurred.canny(50, 150);
+    const contours = edges.findContours(cv.RETR_EXTERNAL, cv.CHAIN_APPROX_SIMPLE);
+    const elements: DetectedElement[] = [];
+
+    for (const contour of contours) {
+      const rect = contour.boundingRect();
+
+      if (!this.isLikelyElement(rect)) {
+        continue;
+      }
+
+      const x = rect.x + offsetX;
+      const y = rect.y + offsetY;
+      const width = rect.width;
+      const height = rect.height;
+
+      elements.push({
+        id: this.generateElementId('edge'),
+        type: this.inferElementTypeFromShape(rect),
+        coordinates: {
+          x,
+          y,
+          width,
+          height,
+          centerX: x + width / 2,
+          centerY: y + height / 2
+        },
+        confidence: 0.6,
+        description: `Edge-detected element (${width}x${height})`,
+        metadata: {
+          detectionMethod: 'edge'
+        }
+      });
+    }
+
+    return elements;
+  }
+
+  private isLikelyElement(rect: cv.Rect): boolean {
+    return (
+      rect.width > 20 &&
+      rect.height > 15 &&
+      rect.width < 400 &&
+      rect.height < 160
+    );
+  }
+
+  private inferElementTypeFromShape(rect: cv.Rect): ElementType {
+    const aspectRatio = rect.width / Math.max(rect.height, 1);
+
+    if (aspectRatio > 1.5 && aspectRatio < 6 && rect.height >= 20 && rect.height <= 60) {
+      return 'button';
+    }
+
+    if (aspectRatio > 3 && rect.height >= 15 && rect.height <= 40) {
+      return 'input';
+    }
+
+    return 'unknown';
+  }
+
+  private extractRegion(image: cv.Mat, region?: BoundingBox): {
+    mat: cv.Mat;
+    offsetX: number;
+    offsetY: number;
+  } {
+    if (!region) {
+      return { mat: image, offsetX: 0, offsetY: 0 };
+    }
+
+    const x = Math.max(0, Math.min(Math.floor(region.x), image.cols - 1));
+    const y = Math.max(0, Math.min(Math.floor(region.y), image.rows - 1));
+    const width = Math.max(1, Math.min(Math.floor(region.width), image.cols - x));
+    const height = Math.max(1, Math.min(Math.floor(region.height), image.rows - y));
+
+    if (width <= 0 || height <= 0) {
+      return { mat: image, offsetX: 0, offsetY: 0 };
+    }
+
+    const rect = new cv.Rect(x, y, width, height);
+    return { mat: image.getRegion(rect), offsetX: x, offsetY: y };
+  }
+
+  private generateElementId(prefix: string): string {
+    return `${prefix}_${Date.now()}_${Math.random().toString(36).slice(2, 11)}`;
+  }
+}

--- a/packages/bytebot-cv/src/detectors/ocr/ocr-detector.ts
+++ b/packages/bytebot-cv/src/detectors/ocr/ocr-detector.ts
@@ -1,0 +1,127 @@
+import { createWorker, Worker } from 'tesseract.js';
+import { BoundingBox, DetectedElement, ElementType } from '../../types';
+
+type RecognizeRectangleOption = {
+  rectangle: {
+    left: number;
+    top: number;
+    width: number;
+    height: number;
+  };
+};
+
+export class OCRDetector {
+  private worker: Worker | null = null;
+
+  async detect(screenshotBuffer: Buffer, region?: BoundingBox): Promise<DetectedElement[]> {
+    const worker = await this.getWorker();
+    const options = region ? this.toRecognizeOptions(region) : undefined;
+    const { data } = await worker.recognize(screenshotBuffer, options);
+
+    if (!data?.words?.length) {
+      return [];
+    }
+
+    const elements: DetectedElement[] = [];
+    const offsetX = region ? Math.max(0, Math.floor(region.x)) : 0;
+    const offsetY = region ? Math.max(0, Math.floor(region.y)) : 0;
+
+    for (const word of data.words) {
+      const confidence = word.confidence ?? 0;
+
+      if (confidence <= 70) {
+        continue;
+      }
+
+      const bbox = word.bbox;
+      const x0 = bbox.x0 + offsetX;
+      const y0 = bbox.y0 + offsetY;
+      const x1 = bbox.x1 + offsetX;
+      const y1 = bbox.y1 + offsetY;
+      const width = x1 - x0;
+      const height = y1 - y0;
+
+      elements.push({
+        id: this.generateElementId('ocr'),
+        type: this.inferElementType(word.text, width, height),
+        coordinates: {
+          x: x0,
+          y: y0,
+          width,
+          height,
+          centerX: x0 + width / 2,
+          centerY: y0 + height / 2
+        },
+        confidence: Math.min(Math.max(confidence / 100, 0), 1),
+        text: word.text,
+        description: `Text element: "${word.text}"`,
+        metadata: {
+          detectionMethod: 'ocr',
+          ocrConfidence: confidence
+        }
+      });
+    }
+
+    return elements;
+  }
+
+  async cleanup(): Promise<void> {
+    if (this.worker) {
+      await this.worker.terminate();
+      this.worker = null;
+    }
+  }
+
+  private async getWorker(): Promise<Worker> {
+    if (!this.worker) {
+      this.worker = await createWorker();
+      await this.worker.loadLanguage('eng');
+      await this.worker.initialize('eng');
+    }
+
+    return this.worker;
+  }
+
+  private toRecognizeOptions(region: BoundingBox): RecognizeRectangleOption {
+    return {
+      rectangle: {
+        left: Math.max(0, Math.floor(region.x)),
+        top: Math.max(0, Math.floor(region.y)),
+        width: Math.max(1, Math.floor(region.width)),
+        height: Math.max(1, Math.floor(region.height))
+      }
+    };
+  }
+
+  private inferElementType(text: string, width: number, height: number): ElementType {
+    const lowerText = text.toLowerCase();
+    const buttonKeywords = [
+      'install',
+      'save',
+      'cancel',
+      'ok',
+      'submit',
+      'login',
+      'sign in',
+      'download'
+    ];
+
+    if (buttonKeywords.some(keyword => lowerText.includes(keyword))) {
+      return 'button';
+    }
+
+    if (lowerText.includes('http') || lowerText.includes('www') || lowerText.includes('.com')) {
+      return 'link';
+    }
+
+    if (height < 40 && width > 100 && lowerText.length < 50) {
+      return 'input';
+    }
+
+    return 'text';
+  }
+
+  private generateElementId(prefix: string): string {
+    return `${prefix}_${Date.now()}_${Math.random().toString(36).slice(2, 11)}`;
+  }
+}

--- a/packages/bytebot-cv/src/detectors/template/template-detector.ts
+++ b/packages/bytebot-cv/src/detectors/template/template-detector.ts
@@ -1,0 +1,120 @@
+import * as cv from 'opencv4nodejs';
+import * as fs from 'fs';
+import * as path from 'path';
+import { BoundingBox, DetectedElement, ElementType } from '../../types';
+
+type TemplateEntry = {
+  name: string;
+  mat: cv.Mat;
+  type: ElementType;
+};
+
+export class TemplateDetector {
+  private templates: TemplateEntry[] = [];
+
+  constructor() {
+    this.loadCommonTemplates();
+  }
+
+  async detect(screenshotBuffer: Buffer, region?: BoundingBox): Promise<DetectedElement[]> {
+    if (!screenshotBuffer?.length || !this.templates.length) {
+      return [];
+    }
+
+    const screenshot = cv.imdecode(screenshotBuffer);
+    const { mat: searchMat, offsetX, offsetY } = this.extractRegion(screenshot, region);
+    const elements: DetectedElement[] = [];
+
+    for (const template of this.templates) {
+      if (searchMat.cols < template.mat.cols || searchMat.rows < template.mat.rows) {
+        continue;
+      }
+
+      const result = searchMat.matchTemplate(template.mat, cv.TM_CCOEFF_NORMED);
+      const { maxLoc, maxVal } = result.minMaxLoc();
+
+      if (maxVal < 0.8) {
+        continue;
+      }
+
+      const x = maxLoc.x + offsetX;
+      const y = maxLoc.y + offsetY;
+      const width = template.mat.cols;
+      const height = template.mat.rows;
+
+      elements.push({
+        id: this.generateElementId('template'),
+        type: template.type,
+        coordinates: {
+          x,
+          y,
+          width,
+          height,
+          centerX: x + width / 2,
+          centerY: y + height / 2
+        },
+        confidence: Math.min(Math.max(maxVal, 0), 1),
+        description: `Template match: ${template.name}`,
+        metadata: {
+          detectionMethod: 'template',
+          templateMatch: maxVal
+        }
+      });
+    }
+
+    return elements;
+  }
+
+  private loadCommonTemplates(): void {
+    const templateDir = path.join(__dirname, 'templates');
+    const definitions: Array<{ name: string; file: string; type: ElementType }> = [
+      { name: 'install-button', file: 'install-button.png', type: 'button' },
+      { name: 'save-button', file: 'save-button.png', type: 'button' }
+    ];
+
+    for (const definition of definitions) {
+      const templatePath = path.join(templateDir, definition.file);
+
+      if (!fs.existsSync(templatePath)) {
+        continue;
+      }
+
+      try {
+        const mat = cv.imread(templatePath);
+        this.templates.push({
+          name: definition.name,
+          mat,
+          type: definition.type
+        });
+      } catch (error) {
+        console.warn(`Failed to load template ${definition.name}:`, (error as Error).message);
+      }
+    }
+  }
+
+  private extractRegion(image: cv.Mat, region?: BoundingBox): {
+    mat: cv.Mat;
+    offsetX: number;
+    offsetY: number;
+  } {
+    if (!region) {
+      return { mat: image, offsetX: 0, offsetY: 0 };
+    }
+
+    const x = Math.max(0, Math.min(Math.floor(region.x), image.cols - 1));
+    const y = Math.max(0, Math.min(Math.floor(region.y), image.rows - 1));
+    const width = Math.max(1, Math.min(Math.floor(region.width), image.cols - x));
+    const height = Math.max(1, Math.min(Math.floor(region.height), image.rows - y));
+
+    if (width <= 0 || height <= 0) {
+      return { mat: image, offsetX: 0, offsetY: 0 };
+    }
+
+    const rect = new cv.Rect(x, y, width, height);
+    return { mat: image.getRegion(rect), offsetX: x, offsetY: y };
+  }
+
+  private generateElementId(prefix: string): string {
+    return `${prefix}_${Date.now()}_${Math.random().toString(36).slice(2, 11)}`;
+  }
+}

--- a/packages/bytebot-cv/src/services/element-detector.service.ts
+++ b/packages/bytebot-cv/src/services/element-detector.service.ts
@@ -1,0 +1,208 @@
+import { DetectedElement, DetectionConfig, BoundingBox, ClickTarget } from '../types';
+import { OCRDetector } from '../detectors/ocr/ocr-detector';
+import { TemplateDetector } from '../detectors/template/template-detector';
+import { EdgeDetector } from '../detectors/edge/edge-detector';
+
+export class ElementDetectorService {
+  private ocrDetector: OCRDetector;
+  private templateDetector: TemplateDetector;
+  private edgeDetector: EdgeDetector;
+
+  constructor() {
+    this.ocrDetector = new OCRDetector();
+    this.templateDetector = new TemplateDetector();
+    this.edgeDetector = new EdgeDetector();
+  }
+
+  async detectElements(
+    screenshotBuffer: Buffer,
+    config: DetectionConfig = this.getDefaultConfig()
+  ): Promise<DetectedElement[]> {
+    // Run detection methods in parallel
+    const detectionPromises: Array<Promise<DetectedElement[]>> = [];
+
+    if (config.enableOCR) {
+      detectionPromises.push(this.ocrDetector.detect(screenshotBuffer, config.searchRegion));
+    }
+
+    if (config.enableTemplateMatching) {
+      detectionPromises.push(this.templateDetector.detect(screenshotBuffer, config.searchRegion));
+    }
+
+    if (config.enableEdgeDetection) {
+      detectionPromises.push(this.edgeDetector.detect(screenshotBuffer, config.searchRegion));
+    }
+
+    const detectionResults = await Promise.all(detectionPromises);
+
+    // Merge and deduplicate results
+    const allElements = detectionResults.flat();
+    const mergedElements = this.mergeOverlappingElements(allElements);
+    
+    return mergedElements.filter(el => el.confidence >= config.confidenceThreshold);
+  }
+
+  async findElementByDescription(
+    elements: DetectedElement[],
+    description: string
+  ): Promise<DetectedElement | null> {
+    // Score elements based on description match
+    const scoredElements = elements.map(element => ({
+      element,
+      score: this.calculateDescriptionMatch(element, description)
+    }));
+
+    // Sort by score and return best match if above threshold
+    scoredElements.sort((a, b) => b.score - a.score);
+    
+    if (scoredElements.length > 0 && scoredElements[0].score > 0.6) {
+      return scoredElements[0].element;
+    }
+
+    return null;
+  }
+
+  async getClickCoordinates(element: DetectedElement): Promise<ClickTarget> {
+    // Calculate optimal click coordinates within element bounds
+    const { coordinates } = element;
+    
+    // For buttons and clickable elements, aim for center
+    // For text fields, aim slightly left of center
+    // For dropdowns, aim for dropdown arrow if detected
+    
+    let targetX = coordinates.centerX;
+    let targetY = coordinates.centerY;
+
+    // Adjust based on element type
+    switch (element.type) {
+      case 'input':
+        targetX = coordinates.x + (coordinates.width * 0.1); // Left side for text input
+        break;
+      case 'dropdown':
+        targetX = coordinates.x + (coordinates.width * 0.9); // Right side for dropdown arrow
+        break;
+      default:
+        // Use center for buttons, links, etc.
+        break;
+    }
+
+    // Generate fallback coordinates in case primary target fails
+    const fallbackCoordinates = [
+      { x: coordinates.centerX, y: coordinates.centerY }, // Center
+      { x: coordinates.x + 10, y: coordinates.y + 10 },   // Top-left + margin
+      { x: coordinates.x + coordinates.width - 10, y: coordinates.centerY } // Right edge
+    ];
+
+    return {
+      coordinates: { x: Math.round(targetX), y: Math.round(targetY) },
+      confidence: element.confidence,
+      method: element.metadata.detectionMethod,
+      fallbackCoordinates
+    };
+  }
+
+  private calculateDescriptionMatch(element: DetectedElement, description: string): number {
+    const desc = description.toLowerCase();
+    let score = 0;
+
+    // Text similarity
+    if (element.text) {
+      const elementText = element.text.toLowerCase();
+      if (elementText.includes(desc) || desc.includes(elementText)) {
+        score += 0.8;
+      } else {
+        // Fuzzy matching logic here
+        score += this.fuzzyMatch(elementText, desc) * 0.6;
+      }
+    }
+
+    // Element type matching
+    if (desc.includes('button') && element.type === 'button') score += 0.3;
+    if (desc.includes('field') && element.type === 'input') score += 0.3;
+    if (desc.includes('link') && element.type === 'link') score += 0.3;
+
+    // Confidence bonus
+    score *= element.confidence;
+
+    return Math.min(score, 1.0);
+  }
+
+  private mergeOverlappingElements(elements: DetectedElement[]): DetectedElement[] {
+    // Implementation to merge elements that overlap significantly
+    // Keep the one with highest confidence
+    const merged: DetectedElement[] = [];
+    
+    for (const element of elements) {
+      const overlapping = merged.find(m => this.calculateOverlap(m.coordinates, element.coordinates) > 0.7);
+      
+      if (overlapping) {
+        if (element.confidence > overlapping.confidence) {
+          // Replace with higher confidence element
+          const index = merged.indexOf(overlapping);
+          merged[index] = element;
+        }
+      } else {
+        merged.push(element);
+      }
+    }
+
+    return merged;
+  }
+
+  private calculateOverlap(box1: BoundingBox, box2: BoundingBox): number {
+    const xOverlap = Math.max(0, Math.min(box1.x + box1.width, box2.x + box2.width) - Math.max(box1.x, box2.x));
+    const yOverlap = Math.max(0, Math.min(box1.y + box1.height, box2.y + box2.height) - Math.max(box1.y, box2.y));
+    const overlapArea = xOverlap * yOverlap;
+    const totalArea = (box1.width * box1.height) + (box2.width * box2.height) - overlapArea;
+    
+    return overlapArea / totalArea;
+  }
+
+  private fuzzyMatch(text1: string, text2: string): number {
+    // Simple implementation - can be enhanced with better fuzzy matching
+    const longer = text1.length > text2.length ? text1 : text2;
+    const shorter = text1.length > text2.length ? text2 : text1;
+    
+    if (longer.length === 0) return 1.0;
+    
+    const editDistance = this.levenshteinDistance(longer, shorter);
+    return (longer.length - editDistance) / longer.length;
+  }
+
+  private levenshteinDistance(str1: string, str2: string): number {
+    const matrix = [];
+    
+    for (let i = 0; i <= str2.length; i++) {
+      matrix[i] = [i];
+    }
+    
+    for (let j = 0; j <= str1.length; j++) {
+      matrix[0][j] = j;
+    }
+    
+    for (let i = 1; i <= str2.length; i++) {
+      for (let j = 1; j <= str1.length; j++) {
+        if (str2.charAt(i - 1) === str1.charAt(j - 1)) {
+          matrix[i][j] = matrix[i - 1][j - 1];
+        } else {
+          matrix[i][j] = Math.min(
+            matrix[i - 1][j - 1] + 1,
+            matrix[i][j - 1] + 1,
+            matrix[i - 1][j] + 1
+          );
+        }
+      }
+    }
+    
+    return matrix[str2.length][str1.length];
+  }
+
+  private getDefaultConfig(): DetectionConfig {
+    return {
+      enableOCR: true,
+      enableTemplateMatching: true,
+      enableEdgeDetection: true,
+      confidenceThreshold: 0.5
+    };
+  }
+}

--- a/packages/bytebot-cv/src/types/index.ts
+++ b/packages/bytebot-cv/src/types/index.ts
@@ -1,0 +1,50 @@
+export interface DetectedElement {
+  id: string;
+  type: ElementType;
+  coordinates: BoundingBox;
+  confidence: number;
+  text?: string;
+  description: string;
+  metadata: ElementMetadata;
+}
+
+export interface BoundingBox {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  centerX: number;
+  centerY: number;
+}
+
+export interface ElementMetadata {
+  detectionMethod: 'ocr' | 'template' | 'edge' | 'accessibility' | 'hybrid';
+  similarity?: number;
+  ocrConfidence?: number;
+  templateMatch?: number;
+}
+
+export type ElementType =
+  | 'button'
+  | 'input'
+  | 'link'
+  | 'text'
+  | 'icon'
+  | 'dropdown'
+  | 'checkbox'
+  | 'unknown';
+
+export interface DetectionConfig {
+  enableOCR: boolean;
+  enableTemplateMatching: boolean;
+  enableEdgeDetection: boolean;
+  confidenceThreshold: number;
+  searchRegion?: BoundingBox;
+}
+
+export interface ClickTarget {
+  coordinates: { x: number; y: number };
+  confidence: number;
+  method: string;
+  fallbackCoordinates?: { x: number; y: number }[];
+}


### PR DESCRIPTION
## Summary
- scaffold the new `@bytebot/cv` package with TypeScript build tooling
- define shared computer-vision types for detected elements and configuration
- implement the initial `ElementDetectorService` coordinating OCR, template, and edge detectors
- add OCR, template, and edge detector implementations with region-aware detection logic and confidence thresholds

## Testing
- not run (opencv/tesseract native dependencies not installed in container)

------
https://chatgpt.com/codex/tasks/task_e_68d46f377f748323a463bf59d60d8681