### PR TITLE
Fix agent build dependencies

### DIFF
--- a/packages/bytebot-agent/tsconfig.build.json
+++ b/packages/bytebot-agent/tsconfig.build.json
@@ -1,8 +1,10 @@
 {
   "extends": "./tsconfig.json",
-  "compilerOptions": {
-    "rootDir": "./src"
-  },
-  "include": ["src/**/*.ts"],
+  "compilerOptions": {},
+  "include": [
+    "src/**/*.ts",
+    "../bytebot-cv/src/**/*.ts",
+    "../bytebot-cv/src/**/*.d.ts"
+  ],
   "exclude": ["node_modules", "test", "dist", "**/*spec.ts"]
 }

--- a/packages/bytebot-cv/src/detectors/edge/edge-detector.ts
+++ b/packages/bytebot-cv/src/detectors/edge/edge-detector.ts
@@ -1,6 +1,9 @@
 import * as cv from 'opencv4nodejs';
 import { BoundingBox, DetectedElement, ElementType } from '../../types';
 
+type CvRect = InstanceType<typeof cv.Rect>;
+type CvMat = ReturnType<typeof cv.imdecode>;
+
 export class EdgeDetector {
   async detect(screenshotBuffer: Buffer, region?: BoundingBox): Promise<DetectedElement[]> {
     if (!screenshotBuffer?.length) {
@@ -49,7 +52,7 @@ export class EdgeDetector {
     return elements;
   }
 
-  private isLikelyElement(rect: cv.Rect): boolean {
+  private isLikelyElement(rect: CvRect): boolean {
     return (
       rect.width > 20 &&
       rect.height > 15 &&
@@ -58,7 +61,7 @@ export class EdgeDetector {
     );
   }
 
-  private inferElementTypeFromShape(rect: cv.Rect): ElementType {
+  private inferElementTypeFromShape(rect: CvRect): ElementType {
     const aspectRatio = rect.width / Math.max(rect.height, 1);
 
     if (aspectRatio > 1.5 && aspectRatio < 6 && rect.height >= 20 && rect.height <= 60) {
@@ -72,8 +75,8 @@ export class EdgeDetector {
     return 'unknown';
   }
 
-  private extractRegion(image: cv.Mat, region?: BoundingBox): {
-    mat: cv.Mat;
+  private extractRegion(image: CvMat, region?: BoundingBox): {
+    mat: CvMat;
     offsetX: number;
     offsetY: number;
   } {

--- a/packages/bytebot-cv/src/detectors/template/template-detector.ts
+++ b/packages/bytebot-cv/src/detectors/template/template-detector.ts
@@ -3,9 +3,11 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { BoundingBox, DetectedElement, ElementType } from '../../types';
 
+type CvMat = ReturnType<typeof cv.imdecode>;
+
 type TemplateEntry = {
   name: string;
-  mat: cv.Mat;
+  mat: CvMat;
   type: ElementType;
 };
 
@@ -92,8 +94,8 @@ export class TemplateDetector {
     }
   }
 
-  private extractRegion(image: cv.Mat, region?: BoundingBox): {
-    mat: cv.Mat;
+  private extractRegion(image: CvMat, region?: BoundingBox): {
+    mat: CvMat;
     offsetX: number;
     offsetY: number;
   } {

--- a/packages/bytebot-cv/src/services/element-detector.service.ts
+++ b/packages/bytebot-cv/src/services/element-detector.service.ts
@@ -170,7 +170,7 @@ export class ElementDetectorService {
   }
 
   private levenshteinDistance(str1: string, str2: string): number {
-    const matrix = [];
+    const matrix: number[][] = [];
     
     for (let i = 0; i <= str2.length; i++) {
       matrix[i] = [i];

--- a/packages/bytebot-cv/src/types/external-modules.d.ts
+++ b/packages/bytebot-cv/src/types/external-modules.d.ts
@@ -1,0 +1,70 @@
+declare module 'opencv4nodejs' {
+  type BoundingFunction = { boundingRect(): Rect };
+
+  interface MatInstance {
+    cols: number;
+    rows: number;
+    cvtColor(code: number): MatInstance;
+    gaussianBlur(size: Size, sigma: number): MatInstance;
+    canny(threshold1: number, threshold2: number): MatInstance;
+    findContours(mode: number, method: number): BoundingFunction[];
+    matchTemplate(mat: MatInstance, method: number): {
+      minMaxLoc(): { maxLoc: { x: number; y: number }; maxVal: number };
+    };
+    minMaxLoc(): { maxLoc: { x: number; y: number }; maxVal: number };
+    getRegion(rect: Rect): MatInstance;
+  }
+
+  interface Rect {
+    x: number;
+    y: number;
+    width: number;
+    height: number;
+  }
+
+  interface Size {
+    width: number;
+    height: number;
+  }
+
+  interface OpenCV {
+    Mat: { new (...args: any[]): MatInstance };
+    Rect: { new (x: number, y: number, width: number, height: number): Rect };
+    Size: { new (width: number, height: number): Size };
+    imdecode(buffer: Buffer): MatInstance;
+    imread(path: string): MatInstance;
+    COLOR_BGR2GRAY: number;
+    RETR_EXTERNAL: number;
+    CHAIN_APPROX_SIMPLE: number;
+    TM_CCOEFF_NORMED: number;
+  }
+
+  const cv: OpenCV;
+  export = cv;
+}
+
+declare module 'tesseract.js' {
+  export interface Word {
+    text: string;
+    confidence?: number;
+    bbox: { x0: number; x1: number; y0: number; y1: number };
+  }
+
+  export interface RecognizeResult {
+    data: {
+      text: string;
+      confidence: number;
+      words?: Word[];
+    };
+  }
+
+  export interface Worker {
+    load(): Promise<void>;
+    loadLanguage(lang: string): Promise<void>;
+    initialize(lang: string): Promise<void>;
+    recognize(image: Buffer | string, options?: Record<string, unknown>): Promise<RecognizeResult>;
+    terminate(): Promise<void>;
+  }
+
+  export function createWorker(options?: Record<string, unknown>): Promise<Worker>;
+}


### PR DESCRIPTION
## Summary
- allow the bytebot-agent build to compile shared bytebot-cv sources
- provide minimal type declarations for opencv4nodejs and tesseract.js
- resolve type errors in the CV detectors and levenshtein helper

## Testing
- npm run build --prefix packages/bytebot-agent

------
https://chatgpt.com/codex/tasks/task_e_68d4887fa09883238fd35cda066fd7e8