### PR TITLE
Fix bytebot-agent production entry point

### DIFF
--- a/packages/bytebot-agent/package.json
+++ b/packages/bytebot-agent/package.json
@@ -16,7 +16,7 @@
     "start:dev": "npm run build --prefix ../shared && nest start --watch",
     "start:debug": "npm run build --prefix ../shared && nest start --debug --watch",
     "prestart:prod": "npm run prisma:prod && npm run build:dist",
-    "start:prod": "node dist/main.js",
+    "start:prod": "node dist/bytebot-agent/src/main.js",
     "lint": "eslint \"{src,apps,libs,test}/**/*.ts\" --fix",
     "test": "jest",
     "test:watch": "jest --watch",


### PR DESCRIPTION
## Summary
- update the bytebot-agent production start script to point at the actual compiled NestJS entry file

## Testing
- npm run build:dist

------
https://chatgpt.com/codex/tasks/task_e_68d491529f648323bc4536d76d955ebe