### PR TITLE
Integrate computer vision tool handlers into agent processor

### DIFF
--- a/packages/bytebot-agent/Dockerfile
+++ b/packages/bytebot-agent/Dockerfile
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/docker/library/node:20-alpine AS base
+FROM public.ecr.aws/docker/library/node:20 AS base
 
 WORKDIR /app
 
@@ -6,6 +6,15 @@ COPY ./packages ./packages
 COPY ./config/universal-coordinates.yaml ./config/universal-coordinates.yaml
 
 WORKDIR /app/packages/bytebot-agent
+
+RUN apt-get update && apt-get install -y \
+    libopencv-dev \
+    tesseract-ocr \
+    tesseract-ocr-eng \
+    python3 \
+    python3-pip \
+    build-essential \
+    && rm -rf /var/lib/apt/lists/*
 
 RUN npm install
 

--- a/packages/bytebotd/Dockerfile
+++ b/packages/bytebotd/Dockerfile
@@ -179,6 +179,14 @@ COPY packages/shared/ /bytebot/packages/shared/
 COPY packages/bytebotd/ /bytebot/packages/bytebotd/
 COPY config/universal-coordinates.yaml /bytebot/config/universal-coordinates.yaml
 WORKDIR /bytebot/packages/bytebotd
+RUN apt-get update && apt-get install -y \
+    libopencv-dev \
+    tesseract-ocr \
+    tesseract-ocr-eng \
+    python3 \
+    python3-pip \
+    build-essential \
+    && rm -rf /var/lib/apt/lists/*
 RUN /usr/bin/npm install --build-from-source
 RUN /usr/bin/npm rebuild uiohook-napi --build-from-source
 


### PR DESCRIPTION
## Summary
- refactor the agent processor to delegate computer vision tool invocations through typed helpers that reuse the ElementDetectorService and cache detected elements
- add typed click handling responses and a shared mouse click wrapper so cached element selections and fallback coordinates flow through one path

## Testing
- npm run lint --prefix packages/bytebot-agent *(fails: existing eslint rules report numerous legacy any-usage violations across the package)*

------
https://chatgpt.com/codex/tasks/task_e_68d5725553548323879f65f455e66664