### PR TITLE
Fix workspace install in agent Dockerfile

### DIFF
--- a/packages/bytebot-agent/Dockerfile
+++ b/packages/bytebot-agent/Dockerfile
@@ -2,10 +2,9 @@ FROM public.ecr.aws/docker/library/node:20 AS base
 
 WORKDIR /app
 
+COPY package.json ./
 COPY ./packages ./packages
 COPY ./config/universal-coordinates.yaml ./config/universal-coordinates.yaml
-
-WORKDIR /app/packages/bytebot-agent
 
 RUN apt-get update && apt-get install -y \
     libopencv-dev \
@@ -16,11 +15,20 @@ RUN apt-get update && apt-get install -y \
     build-essential \
     && rm -rf /var/lib/apt/lists/*
 
-RUN npm install
+RUN npm install --workspace=packages/shared \
+    --workspace=packages/bytebot-cv \
+    --workspace=packages/bytebot-agent
+
+WORKDIR /app/packages/bytebot-agent
 
 RUN npm run build
 
-RUN npm prune --omit=dev
+WORKDIR /app
+RUN npm prune --omit=dev --workspace=packages/shared \
+    --workspace=packages/bytebot-cv \
+    --workspace=packages/bytebot-agent
+
+WORKDIR /app/packages/bytebot-agent
 
 CMD ["sh", "-c", "npm run prisma:prod && node dist/main.js"]
 


### PR DESCRIPTION
## Summary
- include the workspace root manifest in the agent image and install packages via npm workspaces
- prune development dependencies after building so the runtime image only keeps production modules

## Testing
- npm run build --prefix packages/bytebot-agent *(fails: TS2345: Argument of type 'Record<string, any> & { description: string; region?: { x: number; y: number; width: number; height: number; } | undefined; includeAll?: boolean | undefined; }' is not assignable to parameter of type '{ description: string; includeAll: boolean; region?: { x: number; y: number; width: number; height: number; } | undefined; }'.)*

------
https://chatgpt.com/codex/tasks/task_e_68d5a0a665088323a4d3ad09b1ae08cd