### PR TITLE
Patch agent Docker workspace install

### DIFF
--- a/packages/bytebot-agent/Dockerfile
+++ b/packages/bytebot-agent/Dockerfile
@@ -2,10 +2,9 @@ FROM public.ecr.aws/docker/library/node:20 AS base
 
 WORKDIR /app
 
+COPY package.json ./
 COPY ./packages ./packages
 COPY ./config/universal-coordinates.yaml ./config/universal-coordinates.yaml
-
-WORKDIR /app/packages/bytebot-agent
 
 RUN apt-get update && apt-get install -y \
     libopencv-dev \
@@ -16,11 +15,25 @@ RUN apt-get update && apt-get install -y \
     build-essential \
     && rm -rf /var/lib/apt/lists/*
 
-RUN npm install
+RUN npm pkg set dependencies."@bytebot/cv"=../bytebot-cv --workspace=packages/bytebot-agent \
+    && npm pkg set dependencies."@bytebot/cv"=../bytebot-cv --workspace=packages/bytebotd \
+    && npm install --workspace=packages/shared \
+    --workspace=packages/bytebot-cv \
+    --workspace=packages/bytebot-agent
+
+WORKDIR /app/packages/bytebot-agent
 
 RUN npm run build
 
-RUN npm prune --omit=dev
+WORKDIR /app
+RUN npm prune --omit=dev --workspace=packages/shared \
+    --workspace=packages/bytebot-cv \
+    --workspace=packages/bytebot-agent
+
+RUN npm pkg set dependencies."@bytebot/cv"=workspace:* --workspace=packages/bytebot-agent \
+    && npm pkg set dependencies."@bytebot/cv"=workspace:* --workspace=packages/bytebotd
+
+WORKDIR /app/packages/bytebot-agent
 
 CMD ["sh", "-c", "npm run prisma:prod && node dist/main.js"]
 


### PR DESCRIPTION
## Summary
- rewrite the @bytebot/cv workspace dependency to a relative path inside the image before running npm install so workspace protocol errors no longer block Docker builds
- restore the workspace dependency spec after pruning to keep the package metadata unchanged for later tooling

## Testing
- not run (npm install currently fails in this environment due to registry access restrictions)


------
https://chatgpt.com/codex/tasks/task_e_68d5a0a665088323a4d3ad09b1ae08cd