### PR TITLE
Validate computer detect elements input and fix bytebotd Docker workspace install

### DIFF
--- a/packages/bytebot-agent/Dockerfile
+++ b/packages/bytebot-agent/Dockerfile
@@ -2,10 +2,9 @@ FROM public.ecr.aws/docker/library/node:20 AS base
 
 WORKDIR /app
 
+COPY package.json ./
 COPY ./packages ./packages
 COPY ./config/universal-coordinates.yaml ./config/universal-coordinates.yaml
-
-WORKDIR /app/packages/bytebot-agent
 
 RUN apt-get update && apt-get install -y \
     libopencv-dev \
@@ -16,11 +15,25 @@ RUN apt-get update && apt-get install -y \
     build-essential \
     && rm -rf /var/lib/apt/lists/*
 
-RUN npm install
+RUN npm pkg set dependencies."@bytebot/cv"=../bytebot-cv --workspace=packages/bytebot-agent \
+    && npm pkg set dependencies."@bytebot/cv"=../bytebot-cv --workspace=packages/bytebotd \
+    && npm install --workspace=packages/shared \
+    --workspace=packages/bytebot-cv \
+    --workspace=packages/bytebot-agent
+
+WORKDIR /app/packages/bytebot-agent
 
 RUN npm run build
 
-RUN npm prune --omit=dev
+WORKDIR /app
+RUN npm prune --omit=dev --workspace=packages/shared \
+    --workspace=packages/bytebot-cv \
+    --workspace=packages/bytebot-agent
+
+RUN npm pkg set dependencies."@bytebot/cv"=workspace:* --workspace=packages/bytebot-agent \
+    && npm pkg set dependencies."@bytebot/cv"=workspace:* --workspace=packages/bytebotd
+
+WORKDIR /app/packages/bytebot-agent
 
 CMD ["sh", "-c", "npm run prisma:prod && node dist/main.js"]
 

--- a/packages/bytebotd/Dockerfile
+++ b/packages/bytebotd/Dockerfile
@@ -176,6 +176,7 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/*
 
 COPY packages/shared/ /bytebot/packages/shared/
+COPY packages/bytebot-cv/ /bytebot/packages/bytebot-cv/
 COPY packages/bytebotd/ /bytebot/packages/bytebotd/
 COPY config/universal-coordinates.yaml /bytebot/config/universal-coordinates.yaml
 WORKDIR /bytebot/packages/bytebotd
@@ -187,8 +188,11 @@ RUN apt-get update && apt-get install -y \
     python3-pip \
     build-essential \
     && rm -rf /var/lib/apt/lists/*
-RUN /usr/bin/npm install --build-from-source
+RUN npm pkg set dependencies."@bytebot/cv"=../bytebot-cv \
+    && /usr/bin/npm install --build-from-source
 RUN /usr/bin/npm rebuild uiohook-napi --build-from-source
+
+RUN npm pkg set dependencies."@bytebot/cv"=workspace:*
 
 RUN /usr/bin/npm run build
 


### PR DESCRIPTION
## Summary
- validate computer_detect_elements tool input with the existing Zod schema before running detection so defaults like includeAll are applied
- return a descriptive tool result when the input payload fails validation instead of proceeding with undefined values
- copy the bytebot-cv workspace into the bytebotd Docker build context and temporarily rewrite the dependency to a relative path so npm install succeeds inside the container before restoring the original workspace spec

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d5a0a665088323a4d3ad09b1ae08cd