### PR TITLE
Fix production start path

### DIFF
--- a/packages/bytebot-agent/package.json
+++ b/packages/bytebot-agent/package.json
@@ -16,7 +16,7 @@
     "start:dev": "npm run build --prefix ../shared && nest start --watch",
     "start:debug": "npm run build --prefix ../shared && nest start --debug --watch",
     "prestart:prod": "npm run prisma:prod && npm run build:dist",
-    "start:prod": "node dist/bytebot-agent/src/main.js",
+    "start:prod": "node dist/src/main.js",
     "lint": "eslint \"{src,apps,libs,test}/**/*.ts\" --fix",
     "test": "jest",
     "test:watch": "jest --watch",


### PR DESCRIPTION
## Summary
- point the bytebot-agent production start script at the actual NestJS build output

## Testing
- npm install *(fails: npm cannot resolve workspace:* protocol in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d5af5eeb3c832381f94248673c6efb