### PR TITLE
Fix bytebot-agent Docker CMD entrypoint

### DIFF
--- a/packages/bytebot-agent/Dockerfile
+++ b/packages/bytebot-agent/Dockerfile
@@ -35,6 +35,6 @@ RUN npm pkg set dependencies."@bytebot/cv"=workspace:* --workspace=packages/byte
 
 WORKDIR /app/packages/bytebot-agent
 
-CMD ["sh", "-c", "npm run prisma:prod && node dist/main.js"]
+CMD ["sh", "-c", "npm run prisma:prod && node dist/src/main.js"]
 
 


### PR DESCRIPTION
## Summary
- update the bytebot-agent Docker command to invoke the compiled Nest entrypoint from dist/src/main.js

## Testing
- not run (network access to install dependencies is blocked in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68d5b1f452448323bb2969946f6b1bb1